### PR TITLE
Fixed Chef 12.7 deprecation issue

### DIFF
--- a/chef_license_status.rb
+++ b/chef_license_status.rb
@@ -1,8 +1,7 @@
 #!/opt/opscode/embedded/bin/ruby
 # chef_license_status.rb
 
-require 'chef/config'
-require 'chef/rest'
+require 'chef'
 require 'csv'
 require 'socket'
 
@@ -10,7 +9,7 @@ hostname = Socket.gethostname
 chef_server_url = "http://#{hostname}/"
 client_name = 'pivotal'
 signing_key_filename = '/etc/opscode/pivotal.pem'
-rest = Chef::REST.new(chef_server_url, client_name, signing_key_filename)
+rest = Chef::ServerAPI.new(chef_server_url, client_name: client_name, signing_key_filename: signing_key_filename)
 license = rest.get_rest('/license')
 node_count = license['node_count']
 


### PR DESCRIPTION
On newer versions of Chef Server, you'd get the following error:

``` bash
/opt/opscode/embedded/lib/ruby/gems/2.1.0/gems/chef-12.7.0/lib/chef/rest.rb:62:in `initialize': undefined method `log_deprecation' for Chef:Class (NoMethodError)
        from /opt/chef_license_status.rb:13:in `new'
        from /opt/chef_license_status.rb:13:in `<main>'

```

This fixes that issue and updates the script to use the newer `Chef::ServerAPI` class instead of the deprecated `Chef::REST` one.
